### PR TITLE
Add type info for VS Code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@playcanvas/eslint-config": "^1.0.15",
+        "@playcanvas/eslint-config": "^1.0.16",
         "eslint": "^8.6.0"
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.14.1.tgz",
-      "integrity": "sha512-yiA5X6BSIv99DIeRl7PTBxqg7Lx81cx+ghbW6UJJxoVAKX4NxSAdZ7DKTXsSILUL4FuHDNb54AylTndLdLm8+w==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.14.2.tgz",
+      "integrity": "sha512-812igKXDcLEdkwUbJvnhzMy88dBBiDeaf3mMF1jnQwclIObu5UQB8ow1KAvDRN1FQqpB+IsZnpmRA0jZ6KGt3g==",
       "dev": true,
       "dependencies": {
         "comment-parser": "1.3.0",
@@ -68,12 +68,12 @@
       "dev": true
     },
     "node_modules/@playcanvas/eslint-config": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@playcanvas/eslint-config/-/eslint-config-1.0.15.tgz",
-      "integrity": "sha512-vIg/g6DSbM1YUouhgmiXoF+JwWrFjKdO54wbhHnT+C2xjUD0DEAEYA5+AC8brsVlkvZAN1TnfUsqt3HwFzq+cA==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@playcanvas/eslint-config/-/eslint-config-1.0.16.tgz",
+      "integrity": "sha512-Cy1XSyX0kBRtNN0STyE6+nboe1T8/J9RYLTYvRX556Nnz4RGDLN5X1dvPCz7/TWvGxlXwWMH4McGV/TaQ07nqg==",
       "dev": true,
       "dependencies": {
-        "eslint-plugin-jsdoc": "^37.1.0"
+        "eslint-plugin-jsdoc": "^37.5.1"
       },
       "peerDependencies": {
         "eslint": ">= 4"
@@ -358,12 +358,12 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "37.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.4.2.tgz",
-      "integrity": "sha512-hKTIu5m0PxD21ZXdFVFpknEyp9aMvDMzamR+1bkcRHK9MDIYgroRGBQCeHupvcZ5TyGU0EfE+ed0FhLhkbekfQ==",
+      "version": "37.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.5.1.tgz",
+      "integrity": "sha512-WMv/Na5QdpMQao1MR3SgYpGFi2PSrhh/JljlErQru9ZYXf1j9oQVIVCELQV7jcyqKQ/svPqCyU8eMhet9dzP+w==",
       "dev": true,
       "dependencies": {
-        "@es-joy/jsdoccomment": "0.14.1",
+        "@es-joy/jsdoccomment": "0.14.2",
         "comment-parser": "1.3.0",
         "debug": "^4.3.3",
         "escape-string-regexp": "^4.0.0",
@@ -1073,9 +1073,9 @@
   },
   "dependencies": {
     "@es-joy/jsdoccomment": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.14.1.tgz",
-      "integrity": "sha512-yiA5X6BSIv99DIeRl7PTBxqg7Lx81cx+ghbW6UJJxoVAKX4NxSAdZ7DKTXsSILUL4FuHDNb54AylTndLdLm8+w==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.14.2.tgz",
+      "integrity": "sha512-812igKXDcLEdkwUbJvnhzMy88dBBiDeaf3mMF1jnQwclIObu5UQB8ow1KAvDRN1FQqpB+IsZnpmRA0jZ6KGt3g==",
       "dev": true,
       "requires": {
         "comment-parser": "1.3.0",
@@ -1118,12 +1118,12 @@
       "dev": true
     },
     "@playcanvas/eslint-config": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@playcanvas/eslint-config/-/eslint-config-1.0.15.tgz",
-      "integrity": "sha512-vIg/g6DSbM1YUouhgmiXoF+JwWrFjKdO54wbhHnT+C2xjUD0DEAEYA5+AC8brsVlkvZAN1TnfUsqt3HwFzq+cA==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@playcanvas/eslint-config/-/eslint-config-1.0.16.tgz",
+      "integrity": "sha512-Cy1XSyX0kBRtNN0STyE6+nboe1T8/J9RYLTYvRX556Nnz4RGDLN5X1dvPCz7/TWvGxlXwWMH4McGV/TaQ07nqg==",
       "dev": true,
       "requires": {
-        "eslint-plugin-jsdoc": "^37.1.0"
+        "eslint-plugin-jsdoc": "^37.5.1"
       }
     },
     "acorn": {
@@ -1334,12 +1334,12 @@
       }
     },
     "eslint-plugin-jsdoc": {
-      "version": "37.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.4.2.tgz",
-      "integrity": "sha512-hKTIu5m0PxD21ZXdFVFpknEyp9aMvDMzamR+1bkcRHK9MDIYgroRGBQCeHupvcZ5TyGU0EfE+ed0FhLhkbekfQ==",
+      "version": "37.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.5.1.tgz",
+      "integrity": "sha512-WMv/Na5QdpMQao1MR3SgYpGFi2PSrhh/JljlErQru9ZYXf1j9oQVIVCELQV7jcyqKQ/svPqCyU8eMhet9dzP+w==",
       "dev": true,
       "requires": {
-        "@es-joy/jsdoccomment": "0.14.1",
+        "@es-joy/jsdoccomment": "0.14.2",
         "comment-parser": "1.3.0",
         "debug": "^4.3.3",
         "escape-string-regexp": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "mock"
   ],
   "license": "MIT",
-  "module": "src/index.mjs",
+  "main": "src/index.mjs",
   "bugs": {
     "url": "https://github.com/playcanvas/canvas-mock/issues"
   },
@@ -22,7 +22,7 @@
     "extends": "@playcanvas/eslint-config"
   },
   "devDependencies": {
-    "@playcanvas/eslint-config": "^1.0.15",
+    "@playcanvas/eslint-config": "^1.0.16",
     "eslint": "^8.6.0"
   },
   "scripts": {

--- a/src/canvas-rendering-context-2d.mjs
+++ b/src/canvas-rendering-context-2d.mjs
@@ -45,6 +45,12 @@ const functions = [
 ];
 
 class CanvasRenderingContext2D {
+    /** @type {HTMLCanvasElement} */
+    canvas;
+
+    /**
+     * @param {HTMLCanvasElement} canvas - The canvas element to create the context from.
+     */
     constructor(canvas) {
         this.canvas = canvas;
     }

--- a/src/dom-rect.mjs
+++ b/src/dom-rect.mjs
@@ -1,4 +1,22 @@
 class DOMRect {
+    /** @type {number} */
+    x;
+
+    /** @type {number} */
+    y;
+
+    /** @type {number} */
+    width;
+
+    /** @type {number} */
+    height;
+
+    /**
+     * @param {number} x - The x coordinate of the top-left corner of the rectangle.
+     * @param {number} y - The y coordinate of the top-left corner of the rectangle.
+     * @param {number} width - The width of the rectangle.
+     * @param {number} height - The height of the rectangle.
+     */
     constructor(x, y, width, height) {
         this.x = x;
         this.y = y;
@@ -6,18 +24,22 @@ class DOMRect {
         this.height = height;
     }
 
+    /** @type {number} */
     get top() {
         return this.y;
     }
 
+    /** @type {number} */
     get bottom() {
         return this.y + this.height;
     }
 
+    /** @type {number} */
     get left() {
         return this.x;
     }
 
+    /** @type {number} */
     get right() {
         return this.x + this.width;
     }

--- a/src/html-canvas-element.mjs
+++ b/src/html-canvas-element.mjs
@@ -3,6 +3,10 @@ import { HTMLElement } from './html-element.mjs';
 import { WebGLRenderingContext } from './webgl-rendering-context.mjs';
 
 class HTMLCanvasElement extends HTMLElement {
+    /**
+     * @param {string} contextType - The type of context to create.
+     * @returns {CanvasRenderingContext2D|WebGLRenderingContext|null} The requested context.
+     */
     getContext(contextType) {
         switch (contextType) {
             case '2d':

--- a/src/html-element.mjs
+++ b/src/html-element.mjs
@@ -1,6 +1,16 @@
 import { DOMRect } from './dom-rect.mjs';
 
 class HTMLElement {
+    /** @type {number} */
+    width;
+
+    /** @type {number} */
+    height;
+
+    /**
+     * @param {number} width - The width of the element.
+     * @param {number} height - The height of the element.
+     */
     constructor(width, height) {
         this.width = width;
         this.height = height;
@@ -10,6 +20,9 @@ class HTMLElement {
 
     }
 
+    /**
+     * @returns {DOMRect} The bounding rectangle of the element.
+     */
     getBoundingClientRect() {
         return new DOMRect(0, 0, this.width, this.height);
     }

--- a/src/image.mjs
+++ b/src/image.mjs
@@ -1,4 +1,14 @@
 class Image {
+    /** @type {number} */
+    width;
+
+    /** @type {number} */
+    height;
+
+    /**
+     * @param {number} width - The width of the image.
+     * @param {number} height - The height of the image.
+     */
     constructor(width, height) {
         this.width = width;
         this.height = height;

--- a/src/webgl-rendering-context.mjs
+++ b/src/webgl-rendering-context.mjs
@@ -437,22 +437,35 @@ const enums = {
 };
 
 class WebGLRenderingContext {
+    /**
+     * @param {HTMLCanvasElement} canvas - The canvas element to create the context from.
+     */
     constructor(canvas) {
         this.canvas = canvas;
     }
 
+    /** @type {number} */
     get drawingBufferWidth() {
         return this.canvas.width;
     }
 
+    /** @type {number} */
     get drawingBufferHeight() {
         return this.canvas.height;
     }
 
+    /**
+     * @param {string} ext - The extension name.
+     * @returns {object|null} The extension or null if not supported.
+     */
     getExtension(ext) {
         return null;
     }
 
+    /**
+     * @param {number} pname - The parameter to query.
+     * @returns {number} The value of the parameter.
+     */
     getParameter(pname) {
         switch (pname) {
             case this.ACTIVE_TEXTURE:
@@ -627,10 +640,16 @@ class WebGLRenderingContext {
         return null;
     }
 
+    /**
+     * @returns {WebGLShaderPrecisionFormat} The precision format supported by the context.
+     */
     getShaderPrecisionFormat() {
         return new WebGLShaderPrecisionFormat(127, 127, 23);
     }
 
+    /**
+     * @returns {string[]} The extensions supported by the context.
+     */
     getSupportedExtensions() {
         return [];
     }

--- a/src/webgl-shader-precision-format.mjs
+++ b/src/webgl-shader-precision-format.mjs
@@ -1,20 +1,37 @@
 class WebGLShaderPrecisionFormat {
+    /** @type number */
+    #rangeMin;
+
+    /** @type number */
+    #rangeMax;
+
+    /** @type number */
+    #precision;
+
+    /**
+     * @param {number} rangeMin - The base 2 log of the absolute value of the minimum value that can be represented.
+     * @param {number} rangeMax - The base 2 log of the absolute value of the maximum value that can be represented.
+     * @param {number} precision - The number of bits of precision that can be represented. For integer formats this value is always 0.
+     */
     constructor(rangeMin, rangeMax, precision) {
-        this._rangeMin = rangeMin;
-        this._rangeMax = rangeMax;
-        this._precision = precision;
+        this.#rangeMin = rangeMin;
+        this.#rangeMax = rangeMax;
+        this.#precision = precision;
     }
 
+    /** @type {number} */
     get precision() {
-        return this._precision;
+        return this.#precision;
     }
 
+    /** @type {number} */
     get rangeMax() {
-        return this._rangeMax;
+        return this.#rangeMax;
     }
 
+    /** @type {number} */
     get rangeMin() {
-        return this._rangeMin;
+        return this.#rangeMin;
     }
 }
 


### PR DESCRIPTION
* Add JSDoc comment blocks to supply type information to VS Code.
* Use private class fields.
* Change entry point of module (`module` to `main` in `package.json`).
* Bump ESLint config to latest.